### PR TITLE
Missing return statement

### DIFF
--- a/gloox/bot.cpp
+++ b/gloox/bot.cpp
@@ -35,6 +35,7 @@ ostream& operator<<(ostream& os, Message::MessageType type) {
             os << "unknown type";
             break;
     }
+    return os;
 }
 
 ostream& operator<<(ostream& os, const Message& stanza) {


### PR DESCRIPTION
Without it, recent systems will see a segfault.
bug report: #2 